### PR TITLE
Add tag support to roon theme.

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -416,7 +416,7 @@ article #home_link:hover {
     color: #21272d;
     background-color: #ededee
 }
-article time, article time a {
+article time, article time a, article .tags, article .tags a {
     color: #a4adb6;
     text-rendering: optimizeLegibility
 }
@@ -448,6 +448,9 @@ article>header .count {
     font-size: 14px;
     margin-left: 30px;
     color: #a4adb6
+}
+article .meta .tags a:hover {
+    color: #21272d;
 }
 article .text {
     font-family: "Helvetica Neue", "Helvetica-Neue", helvetica, sans-serif;

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -13,7 +13,7 @@
     {{/if}}
 
     <div class="meta">
-        <time datetime="{{date format='YYYY-MM-DD'}}"><a href="{{url}}">{{date format="MMMM DD, YYYY"}}</a></time>
+        <time datetime="{{date format='YYYY-MM-DD'}}"><a href="{{url}}">{{date format="MMMM DD, YYYY"}}</a></time> <span class="tags">{{tags prefix=" on "}}</span>
     </div>
 
     <header>

--- a/post.hbs
+++ b/post.hbs
@@ -13,7 +13,7 @@
     <article role="main" class="{{#if image}}image{{/if}}">
         <header>
             <a href="{{@blog.url}}" id="home_link">«</a>
-            <div class="meta"><time datetime="{{date format='YYYY-MM-DD'}}"><a href="{{url}}">{{date format="MMMM DD, YYYY"}}</a></time> <span class="count" id="js-reading-time"></span></div>
+            <div class="meta"><time datetime="{{date format='YYYY-MM-DD'}}"><a href="{{url}}">{{date format="MMMM DD, YYYY"}}</a></time> <span class="tags">{{tags prefix=" on "}}</span> <span class="count" id="js-reading-time"></span></div>
             <h1>{{title}}</h1>
         </header>
 


### PR DESCRIPTION
closes #9
 - add {{tags}} output to post.hbs
 - add {{tags}} output to loop.hbs
 - add selectors to screen.css style output matching other .meta elements

@TODO: color property/values should probably just be moved to `article .meta {}` to reduce specificity and remove second rule.