### PR TITLE
Add next & previous post links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "Roon",
-  "version": "1.0"
+  "version": "1.1"
 }

--- a/post.hbs
+++ b/post.hbs
@@ -101,6 +101,21 @@
         </div>
     </div>
 
-{{/post}}
+    <div id="post_nav">
+        <nav role="navigation">
+            {{#next_post}}
+                <a href="{{url}}" id="post_next" title="Next Post">
+                    <span aria-hidden="true" data-icon=">"></span>
+                    The Newer Post
+                </a>
+            {{/next_post}}
+            {{#prev_post}}
+                <a href="{{url}}" id="post_prev" title="Previous Post">
+                    Something Older
+                    <span aria-hidden="true" data-icon=">"></span>
+                </a>
+            {{/prev_post}}
+        </nav>
+    </div>
 
-{{!-- TODO: Add next/prev posts --}}
+{{/post}}


### PR DESCRIPTION
Closes #1

- Added `{{#next_post}}` and `{{#prev_post}}` links using the pre-existing CSS
- Update package version from 1.0 to 1.1